### PR TITLE
Fix Eel card movement

### DIFF
--- a/src/isomorphic/cards.js
+++ b/src/isomorphic/cards.js
@@ -45,7 +45,7 @@
       new SimpleCard('Frog','Arcane Wonders',  [[-2,0], [-1,1], [1,-1]]),
       new SimpleCard('Goose','Arcane Wonders',  [[-1,1],[-1,0],[1,0],[1,-1]]),
       new SimpleCard('Horse','Arcane Wonders',  [[-1,0], [0, 1], [0, -1]]),
-      new SimpleCard('Eel','Arcane Wonders',  [[-1,1], [-1,-1], [0,1]]),
+      new SimpleCard('Eel','Arcane Wonders',  [[-1,1], [-1,-1], [1,0]]),
       new SimpleCard('Rabbit','Arcane Wonders',  [[-1,-1], [1,1], [2,0]]),
       new SimpleCard('Rooster','Arcane Wonders',  [[-1,-1], [-1,0], [1,0], [1,1]]),
       new SimpleCard('Ox','Arcane Wonders',  [[0,1], [0,-1], [1,0]]),


### PR DESCRIPTION
Currently the Eel card allows movement 1 square up, this should be 1 square left, the movement vector is just flipped.